### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -527,6 +527,9 @@ jobs:
 
   security-scan:
     name: Security Scan
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     continue-on-error: true
     


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/9](https://github.com/commjoen/3dgame/security/code-scanning/9)

To address the issue, set a `permissions` block for the `security-scan` job to restrict the `GITHUB_TOKEN`'s access. The job almost exclusively reads repository data but does upload SARIF results, so it requires `security-events: write` permission for that step. The minimal correct permissions block for this job is:
```yaml
permissions:
  contents: read
  security-events: write
```
This block should be added directly under the job's definition (after the job name or `runs-on` key). This change only affects the `security-scan` job; other jobs are unaffected. No new methods, variable definitions, or imports are required—just a modification to the YAML structure in `.github/workflows/ci-cd.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
