### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -255,7 +255,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
+    permissions:
+      contents: read
     outputs:
       pages-artifact-id: ${{ steps.pages-artifact.outputs.artifact-id }}
       


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/8](https://github.com/commjoen/3dgame/security/code-scanning/8)

To resolve this issue, we should explicitly add a `permissions:` block to the `prepare-pages` job in `.github/workflows/ci-cd.yml`. The minimal starting point, as recommended, is `contents: read`, which gives read-only access to repository contents for GITHUB_TOKEN. This allows steps such as `actions/checkout` and build processes to work, but prevents unintended writes. The block should be inserted directly beneath the job-level configuration, ideally after the `runs-on`, `needs`, and `if` keys, and before `outputs:` (line 259). No imports or additional methods are required; just add the YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
