### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -225,6 +225,8 @@ jobs:
   build:
     name: Build Application
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [validate]
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/7](https://github.com/commjoen/3dgame/security/code-scanning/7)

To fix the problem, you should explicitly set the `permissions` for the `build` job in `.github/workflows/ci-cd.yml`. The least-privilege that supports the current job logic is `contents: read`, which is sufficient for actions like `actions/checkout` to work. Place this key under the `build` job, aligning at the job-attribute indentation, just below `runs-on` and `needs`. No changes to the workflow logic or steps are needed. Each job should be independently adjusted, unless you want to set stricter permissions at the workflow root.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
