### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/6](https://github.com/commjoen/3dgame/security/code-scanning/6)

To fix the issue, the workflow should declare a `permissions` key that restricts the GitHub Actions `GITHUB_TOKEN` to the least privilege needed. This can be done at the workflow root (affecting all jobs), or for more granular control, at each job block. Given the recommendation, the minimal starting point should be at least `contents: read`, which allows jobs to check out code but not write to repository contents. If any jobs need more privilege, increase their permissions only as strictly needed. The safest and simplest edit is to add the following block at the very top (after the workflow name but before `on:`):

```yaml
permissions:
  contents: read
```

This instructs GitHub to set the token to read-only scope for repository contents (code, etc.) for every job that does not specify its own permissions block. If a particular job needs write permission for something (e.g., creating releases, deploying, etc.), add or override the permissions as needed for that job. However, from the visible jobs, none seem to require write permission for contents; uploading artifacts does not require repository write.

Only one file needs editing: `.github/workflows/ci-cd.yml`. Add the recommended block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
