### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -125,6 +125,8 @@ jobs:
 
   mobile-compatibility:
     name: Mobile Compatibility Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: validate
     continue-on-error: true


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/5](https://github.com/commjoen/3dgame/security/code-scanning/5)

To fix this issue, you should explicitly set the minimum required permissions for the `mobile-compatibility` job in the `.github/workflows/ci-cd.yml` file. For jobs that only need to check out code and interact with artifacts, `contents: read` is the minimal required permission unless there is some action that specifically needs more (none are shown here). You should add a `permissions:` block under `mobile-compatibility:` with `contents: read`. This block should be placed as a direct child of the job definition (at the same level as `name:` and `runs-on:`). No functional change in the workflow will occur; this only tightens the permissions for security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
