### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/4](https://github.com/commjoen/3dgame/security/code-scanning/4)

To fix the issue, introduce an explicit `permissions` block at the workflow root so all jobs inherit minimal privileges. For these jobs, `contents: read` will restrict the workflow's access to repository contents for downloading code, which is sufficient for linting/testing/building. Artifact uploading through `actions/upload-artifact` does not require additional repository write permissions, as it interacts with workflow storage, not the repository itself. If in the future a job needs more privileges, a job-specific block can be added. The fix should go immediately after the `name:` line and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
