### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/3](https://github.com/commjoen/3dgame/security/code-scanning/3)

To fix the problem, you need to add an explicit `permissions` block—either at the workflow root level (to apply to all jobs) or at the job level if different jobs have different requirements. The safest approach is to add it at the root level, using `contents: read` for most CI/CD workflows, and then override per-job for jobs that do need broader permissions (e.g., if uploading releases, commenting on PRs, etc.). In this case, as the error is specifically flagged in the `test` job, and the other jobs shown also only read repository contents, adding a root-level block is appropriate. Add immediately after the workflow `name`. If a job does later need broader permissions, override locally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
