### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/2](https://github.com/commjoen/3dgame/security/code-scanning/2)

To fix the problem, you must specify a `permissions` block in your workflow that restricts the default permissions of the GITHUB_TOKEN. The least privilege needed for most jobs is `contents: read`, to allow checking out code but disallow writing to the repository.  

The best way to implement this is to add a `permissions:` block at the root (top-level) of your workflow YAML file (.github/workflows/ci-cd.yml), just after the workflow `name:` and before `on:`. This will apply to all jobs unless a job defines its own permissions. If individual jobs require more or different permissions, add a job-specific `permissions:` block under that job(s).

No further code or imports are needed—just add the block:

```yaml
permissions:
  contents: read
```

This should be added after line 1 (after `name: CI/CD Pipeline` and before `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
