### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   dependabot:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/1](https://github.com/commjoen/3dgame/security/code-scanning/1)

To fix this problem, you should explicitly set the `permissions` block at the job (or workflow) level to restrict the token's privileges to only what is required. In this case, the workflow reviews and merges pull requests, which requires `pull-requests: write`, and may also need `contents: read` to interact with the repository's content minimally. This can be accomplished by adding:
```yaml
permissions:
  contents: read
  pull-requests: write
```
either at the workflow root (after `name:`) or within the `dependabot` job. The standard and clearest approach is to set it at the job level, directly above `runs-on:` for the `dependabot` job (since there is only one job). No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
