### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/tests/integration/github-pages-simulation.test.js
+++ b/tests/integration/github-pages-simulation.test.js
@@ -65,7 +65,10 @@ describe('GitHub Pages Deployment Simulation', () => {
         // Only use resolved path if validated
         fsPath = fsPathResolved
       } catch (err) {
-        // Path does not exist, will fall back to 404 below
+        // Failed to resolve path properly: immediately serve 404 and stop
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+        return;
       }
 
       // Handle 404s with the 404.html file (GitHub Pages behavior)


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/3dgame/security/code-scanning/14](https://github.com/commjoen/3dgame/security/code-scanning/14)

To fully remediate this issue, we must ensure that **only validated, normalized, and confined paths are used for any file operations**. Specifically:

- If path resolution or validation fails (in the try-catch block), we should not allow fallback to potentially unvalidated `fsPath`—we must immediately return a 404 or similar error.
- Only after a path has passed normalization and confinement checks (inside the try block) should it be used for subsequent operations (such as `fs.existsSync`, `fs.statSync`, and `fs.createReadStream`).

**Steps to fix:**
1. After the try-catch path validation block (lines 50-67), if an exception occurred, immediately reply with a 404 response rather than defaulting back to an unvalidated path.
2. Remove any `fs.existsSync` or filesystem access using a possibly unvalidated path (i.e., never access the un-normed/unchecked path).
3. Ensure all code paths only ever use the validated/confined version of `fsPath`.

**Required changes:**
- Replace lines after the try-catch block to ensure 404 is served if any validation fails.
- No new imports or library dependencies needed, just code logic fixes within the server handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
